### PR TITLE
Count players from server, not per world

### DIFF
--- a/src/com/untamedears/DynCap/DynCapPlugin.java
+++ b/src/com/untamedears/DynCap/DynCapPlugin.java
@@ -82,15 +82,6 @@ public class DynCapPlugin extends JavaPlugin implements Listener {
 	}
 	
 	public int getPlayerCount() {
-		int playerCount = 0;
-		
-		List<World> worlds = this.getServer().getWorlds();
-		for (World world : worlds) {
-			if (world != null) {
-				playerCount += world.getPlayers().size();
-			}
-		}
-		
-		return playerCount;
+		return this.getServer().getOnlinePlayers().length;
 	}
 }


### PR DESCRIPTION
Not sure why things have broken recently, but this just changes the way players are retrieved. It uses the server's list of all online players rather than trying to iterate through the worlds.
